### PR TITLE
swap to bindgen cli for no_std

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/target
 Cargo.lock
+wrapper.h

--- a/wasm3-sys/Cargo.toml
+++ b/wasm3-sys/Cargo.toml
@@ -13,5 +13,4 @@ wasi = []
 libc = "^0.2"
 
 [build-dependencies]
-bindgen = "0.52"
 cc = "1"

--- a/wasm3-sys/build.rs
+++ b/wasm3-sys/build.rs
@@ -1,43 +1,71 @@
 use std::env;
 use std::ffi::{OsStr, OsString};
 use std::fs;
-use std::io;
+use std::io::{BufWriter, Result, Write};
 use std::path::PathBuf;
 
-fn gen_bindings() -> io::Result<()> {
+fn gen_bindings() -> Result<()> {
     let whitelist_regex =
         "((?:I|c_)?[Mm]3.*)|.*Page.*|Module_.*|EmitWord_impl|op_CallRawFunction|Compile_Function";
-    let bindgen = bindgen::builder()
-        .use_core()
-        .ctypes_prefix("libc")
-        .layout_tests(false)
-        .generate_comments(false)
-        .default_enum_style(bindgen::EnumVariation::ModuleConsts)
-        .whitelist_function(whitelist_regex)
-        .whitelist_type(whitelist_regex)
-        .whitelist_var(whitelist_regex)
-        .derive_debug(false);
-    let bindgen = fs::read_dir("wasm3/source")?
-        .filter_map(Result::ok)
-        .map(|entry| entry.path())
-        .filter(|path| path.extension().and_then(OsStr::to_str) == Some("h"))
-        .fold(bindgen, |bindgen, path| {
-            bindgen.header(path.to_str().unwrap())
-        });
+
+    let root_path = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    let wrapper_file = root_path.join("wrapper.h");
+    let wrapper_file = wrapper_file.to_str().unwrap();
+
+    {
+        let file = fs::File::create(wrapper_file).unwrap();
+        let mut file = BufWriter::new(file);
+        for path in fs::read_dir("wasm3/source")
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|path| path.extension().and_then(OsStr::to_str) == Some("h"))
+        {
+            writeln!(file, "#include <{}>", path.to_str().unwrap()).unwrap();
+        }
+    }
+
+    let mut bindgen = std::process::Command::new("bindgen");
+
+    let bindgen = bindgen
+        .arg(wrapper_file)
+        .arg("--use-core")
+        .arg("--ctypes-prefix")
+        .arg("libc")
+        .arg("--no-layout-tests")
+        .arg("--no-doc-comments")
+        .arg("--whitelist-function")
+        .arg(whitelist_regex)
+        .arg("--whitelist-type")
+        .arg(whitelist_regex)
+        .arg("--whitelist-var")
+        .arg(whitelist_regex)
+        .arg("--no-derive-debug");
+
     let bindgen = [
         "f64", "f32", "u64", "i64", "u32", "i32", "u16", "i16", "u8", "i8",
     ]
     .iter()
-    .fold(bindgen, |bindgen, &ty| bindgen.blacklist_type(ty));
+    .fold(bindgen, |bindgen, &ty| {
+        bindgen.arg("--blacklist-type").arg(ty)
+    });
 
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    bindgen
-        .generate()
-        .expect("Unable to generate bindings")
-        .write_to_file(out_path.join("bindings.rs"))
+    let status = bindgen
+        .arg("-o")
+        .arg(out_path.join("bindings.rs").to_str().unwrap())
+        .status()
+        .expect("Unable to generate bindings");
+
+    if !status.success() {
+        panic!("Failed to run bindgen: {:?}", status);
+    }
+
+    Ok(())
 }
 
-fn main() -> io::Result<()> {
+fn main() -> Result<()> {
     gen_bindings()?;
     // build
     let mut cfg = cc::Build::new();


### PR DESCRIPTION
Thanks so much for your recent no_std support. There is one problem still, in that using deps with shared features from build.rs pollutes the no_std features with std features. Its sadly a well known problem with the only solution being to swap bindgen api for cli.
https://github.com/rust-lang/cargo/issues/5730


I think this is pretty close to complete, but not quite right yet as the pathing on the headers is broken but thought Id open the pr to start discussion



```
jacobrosenthal@Jacobs-MacBook-Air pygamer (embedded-graphics-addons) $ cargo run --example ferris_img --release
   Compiling wasm3-sys v0.1.0 (/Users/jacobrosenthal/Downloads/wasm3-rs/wasm3-sys)
   Compiling atsamd-hal v0.8.2 (/Users/jacobrosenthal/Downloads/atsamd/hal)
error: failed to run custom build command for `wasm3-sys v0.1.0 (/Users/jacobrosenthal/Downloads/wasm3-rs/wasm3-sys)`

Caused by:
  process didn't exit successfully: `/Users/jacobrosenthal/Downloads/atsamd/boards/pygamer/target/release/build/wasm3-sys-cdaaa8881bf2f36a/build-script-build` (exit code: 101)
--- stdout
cargo:warning=couldn't execute `llvm-config --prefix` (error: No such file or directory (os error 2))
cargo:warning=set the LLVM_CONFIG_PATH environment variable to a valid `llvm-config` executable

--- stderr
/Users/jacobrosenthal/Downloads/atsamd/boards/pygamer/target/thumbv7em-none-eabihf/release/build/wasm3-sys-a2cd32265d2c23a2/out/wrapper.h:1:10: fatal error: 'wasm3/source/m3_api_wasi.h' file not found
/Users/jacobrosenthal/Downloads/atsamd/boards/pygamer/target/thumbv7em-none-eabihf/release/build/wasm3-sys-a2cd32265d2c23a2/out/wrapper.h:1:10: fatal error: 'wasm3/source/m3_api_wasi.h' file not found, err: true
thread 'main' panicked at 'Unable to generate bindings: ()', src/libcore/result.rs:1165:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
thread 'main' panicked at 'Failed to run bindgen: ExitStatus(ExitStatus(256))', /Users/jacobrosenthal/Downloads/wasm3-rs/wasm3-sys/build.rs:61:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.

warning: build failed, waiting for other jobs to finish...
error: build failed
jacobrosenthal@Jacobs-MacBook-Air pygamer (embedded-graphics-addons) $ 

```