### PR TITLE
Fix wrong WasmType::TYPE_INDEX value for the () type

### DIFF
--- a/src/ty.rs
+++ b/src/ty.rs
@@ -146,7 +146,7 @@ impl WasmType for f64 {
 
 impl WasmType for () {
     #[doc(hidden)]
-    const TYPE_INDEX: u8 = ffi::_bindgen_ty_1::c_m3Type_void as u8;
+    const TYPE_INDEX: u8 = ffi::_bindgen_ty_1::c_m3Type_none as u8;
     #[doc(hidden)]
     fn put_on_stack(self, _: &mut [u64]) {}
     #[doc(hidden)]


### PR DESCRIPTION
TYPE_INDEX for the unit type should be c_m3Type_none instead of c_m3Type_void since WASM spec does not define void as a valid type.

There is also a comment about this in wasm3, although it's well hidden: https://github.com/wasm3/wasm3/blob/f75f647c61abc2abdd212ac6f34b026d48818a0f/source/m3_bind.c#L69

This PR fixes this, making it possible to call WASM functions that do not return a value.