### PR TITLE
Fix sysroot flag not passed to C build

### DIFF
--- a/wasm3-sys/Cargo.toml
+++ b/wasm3-sys/Cargo.toml
@@ -22,6 +22,7 @@ cty = "0.2"
 
 [build-dependencies]
 cc = "1"
+shlex = "0.1.1"
 
 [build-dependencies.bindgen]
 version = "0.54"

--- a/wasm3-sys/build.rs
+++ b/wasm3-sys/build.rs
@@ -143,7 +143,7 @@ fn main() {
         .include(WASM3_SOURCE);
 
     // Add any extra arguments from the environment to the CC command line.
-    if let Some(extra_clang_args) = std::env::var("BINDGEN_EXTRA_CLANG_ARGS").ok() {
+    if let Ok(extra_clang_args) = std::env::var("BINDGEN_EXTRA_CLANG_ARGS") {
         // Try to parse it with shell quoting. If we fail, make it one single big argument.
         if let Some(strings) = shlex::split(&extra_clang_args) {
             strings.iter().for_each(|string| {


### PR DESCRIPTION
This fixes the issue in #20 , caused by `sysroot` passed to bindgen but missed in the `cc` build. The implementation is basically taken from bindgen too: https://github.com/rust-lang/rust-bindgen/pull/1537

